### PR TITLE
bunch examples to version 0.10.3

### DIFF
--- a/examples/modeler/pom.xml
+++ b/examples/modeler/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>de.countandcare</groupId>
     <artifactId>webjar-bpmn-js-modeler-jsfsample</artifactId>
-    <version>0.10.2</version>
+    <version>0.10.3</version>
     <packaging>war</packaging>
 
     <properties>
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>bpmn-js</artifactId>    
-            <version>0.10.2</version>
+            <version>0.10.3</version>
         </dependency>
     </dependencies>
 
@@ -56,6 +56,15 @@
                 <artifactId>jetty-maven-plugin</artifactId>
                 <version>7.6.14.v20131031</version>
             </plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<source>1.7</source>
+					<target>1.7</target>
+					<encoding>UTF-8</encoding>
+				</configuration>
+			</plugin>
         </plugins>
     </build>
 </project>

--- a/examples/modeler/src/main/webapp/index.xhtml
+++ b/examples/modeler/src/main/webapp/index.xhtml
@@ -10,8 +10,8 @@
 			<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
 
 			<!-- load diagram-js styles and bpmn styles including the cool bpmn font -->
-			<h:outputStylesheet library="webjars" name="bpmn-js/0.10.2-0/assets/diagram-js.css" />
-			<h:outputStylesheet library="webjars" name="bpmn-js/0.10.2-0/assets/bpmn-font/css/bpmn-embedded.css" />
+			<h:outputStylesheet library="webjars" name="bpmn-js/0.10.3/assets/diagram-js.css" />
+			<h:outputStylesheet library="webjars" name="bpmn-js/0.10.3/assets/bpmn-font/css/bpmn-embedded.css" />
 
 			<!-- load jquery -->
 			<h:outputScript library="webjars" name="jquery/2.1.3/jquery.js"/>
@@ -23,7 +23,7 @@
 			<h:outputScript library="webjars" name="jquery-mousewheel/3.1.11/jquery.mousewheel.js"/>
 
 			<!-- bpmn-js viewer -->
-			<h:outputScript library="webjars" name="bpmn-js/0.10.2-0/bpmn-modeler.min.js" />
+			<h:outputScript library="webjars" name="bpmn-js/0.10.3/bpmn-modeler.min.js" />
 		</h:head>
 		<h:body>
  			<!-- to draw on -->

--- a/examples/viewer/pom.xml
+++ b/examples/viewer/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>de.countandcare</groupId>
-    <artifactId>webjar-bpmn-js-modeler-jsfsample</artifactId>
+    <artifactId>webjar-bpmn-js-viewer-jsfsample</artifactId>
     <version>0.0.1-SNAPSHOT</version>
     <packaging>war</packaging>
 
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>bpmn-js</artifactId>
-            <version>0.10.2</version>
+            <version>0.10.3</version>
         </dependency>
     </dependencies>
 
@@ -56,6 +56,15 @@
                 <artifactId>jetty-maven-plugin</artifactId>
                 <version>7.6.14.v20131031</version>
             </plugin>
+            <plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<source>1.7</source>
+					<target>1.7</target>
+					<encoding>UTF-8</encoding>
+				</configuration>
+			</plugin>
         </plugins>
     </build>
 </project>

--- a/examples/viewer/src/main/webapp/index.xhtml
+++ b/examples/viewer/src/main/webapp/index.xhtml
@@ -10,8 +10,8 @@
 			<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
 
 			<!-- load diagram-js styles and bpmn styles including the cool bpmn font -->
-			<h:outputStylesheet library="webjars" name="bpmn-js/0.10.2-0/assets/diagram-js.css" />
-			<h:outputStylesheet library="webjars" name="bpmn-js/0.10.2-0/assets/bpmn-font/css/bpmn-embedded.css" />
+			<h:outputStylesheet library="webjars" name="bpmn-js/0.10.3/assets/diagram-js.css" />
+			<h:outputStylesheet library="webjars" name="bpmn-js/0.10.3/assets/bpmn-font/css/bpmn-embedded.css" />
 
 			<!-- load jquery -->
 			<h:outputScript library="webjars" name="jquery/2.1.3/jquery.js"/>
@@ -23,7 +23,7 @@
 			<h:outputScript library="webjars" name="jquery-mousewheel/3.1.11/jquery.mousewheel.js"/>
 
 			<!-- bpmn-js viewer -->
-  			<h:outputScript library="webjars" name="bpmn-js/0.10.2-0/bpmn-navigated-viewer.min.js" />
+  			<h:outputScript library="webjars" name="bpmn-js/0.10.3/bpmn-navigated-viewer.min.js" />
 		</h:head>
 		<h:body>
  			<!-- to draw on -->


### PR DESCRIPTION
I cleaned the examples to use the latest version on maven central (0.10.3) add the java compiler version to supress nasty eclipse errors. I also renamed the articfact of the viewer to 'webjar-bpmn-js-viewer-jsfsample'.
